### PR TITLE
Refactor custom.rs to support UniFFI 0.29 custom types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,7 @@ required-features = ["binary"]
 anyhow = "1"
 paste = "1"
 heck = "0.5"
-uniffi = { workspace = true, features = [
-    "build", "tokio"
-] }
+uniffi = { workspace = true }
 uniffi_dart_macro = { path = "./uniffi_dart_macro" }
 uniffi_bindgen = { workspace = true }
 camino = "1"
@@ -66,14 +64,13 @@ members = [
 # Ignore a few tests for now
 exclude = [
     "fixtures/coverall",
-    "fixtures/custom_types",
     "fixtuers/callbacks",
     "fixtuers/dispose",
     "fixtuers/dart_async",
 ]
 
 [workspace.dependencies]
-uniffi = { version = "0.29.0" }
-uniffi_bindgen = { version = "0.29.0" }
-uniffi_build = { version = "0.29.0" }
-uniffi_testing = { version = "0.29.0" }
+uniffi = { version = "0.29.3", features = ["build", "tokio"] }
+uniffi_bindgen = { version = "0.29.3" }
+uniffi_build = { version = "0.29.3" }
+uniffi_testing = { version = "0.29.3" }

--- a/fixtures/custom_types/build.rs
+++ b/fixtures/custom_types/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    //uniffi_dart::generate_scaffolding("./src/api.udl".into()).unwrap();
+    uniffi_dart::generate_scaffolding("./src/api.udl".into()).unwrap();
 }

--- a/fixtures/custom_types/src/api.udl
+++ b/fixtures/custom_types/src/api.udl
@@ -13,4 +13,10 @@ typedef f64 TimeIntervalSecDbl;
 [Custom]
 typedef f32 TimeIntervalSecFlt;
 
-namespace custom_types { };
+namespace custom_types {
+    CustomTypesDemo get_custom_types_demo(CustomTypesDemo? v);
+};
+
+dictionary CustomTypesDemo {
+    Handle handle;
+};

--- a/fixtures/custom_types/src/lib.rs
+++ b/fixtures/custom_types/src/lib.rs
@@ -1,7 +1,30 @@
-// use uniffi;
+use uniffi;
 // use url::Url;
 
-// pub struct Handle(pub i64);
+// Simple custom type for testing UniFFI 0.29 custom types
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Handle(pub i64);
+
+// Use the new custom_type! macro for UniFFI 0.29
+uniffi::custom_type!(Handle, i64);
+
+impl From<i64> for Handle {
+    fn from(val: i64) -> Self {
+        Handle(val)
+    }
+}
+
+impl From<Handle> for i64 {
+    fn from(obj: Handle) -> i64 {
+        obj.0
+    }
+}
+
+impl std::fmt::Display for Handle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Handle({})", self.0)
+    }
+}
 
 // pub struct TimeIntervalMs(pub i64);
 
@@ -81,24 +104,16 @@
 //     }
 // }
 
-// #[derive(uniffi::Record)]
-// pub struct CustomTypesDemo {
-//     url: Url,
-//     handle: Handle,
-//     time_interval_ms: TimeIntervalMs,
-//     time_interval_sec_dbl: TimeIntervalSecDbl,
-//     time_interval_sec_flt: TimeIntervalSecFlt,
-// }
+// Record struct (no derive macro - let UDL handle it)
+pub struct CustomTypesDemo {
+    pub handle: Handle,
+}
 
-// #[uniffi::export]
-// pub fn get_custom_types_demo(v: Option<CustomTypesDemo>) -> CustomTypesDemo {
-//     v.unwrap_or_else(|| CustomTypesDemo {
-//         url: Url::parse("http://example.com/").unwrap(),
-//         handle: Handle(123),
-//         time_interval_ms: TimeIntervalMs(456000),
-//         time_interval_sec_dbl: TimeIntervalSecDbl(456.0),
-//         time_interval_sec_flt: TimeIntervalSecFlt(777.0),
-//     })
-// }
+// Function (no export macro - let UDL handle it) 
+pub fn get_custom_types_demo(v: Option<CustomTypesDemo>) -> CustomTypesDemo {
+    v.unwrap_or_else(|| CustomTypesDemo {
+        handle: Handle(123),
+    })
+}
 
-// uniffi::include_scaffolding!("api");
+uniffi::include_scaffolding!("api");

--- a/fixtures/custom_types/tests/mod.rs
+++ b/fixtures/custom_types/tests/mod.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 
-// #[test]
-// fn custom_types() -> Result<()> {
-//     uniffi_dart::testing::run_test("custom_types", "src/api.udl", None)
-// }
+#[test]
+fn custom_types() -> Result<()> {
+    uniffi_dart::testing::run_test("custom_types", "src/api.udl", None)
+}

--- a/src/gen/custom.rs
+++ b/src/gen/custom.rs
@@ -1,81 +1,100 @@
-use super::oracle::DartCodeOracle;
-use super::CodeType;
-use super::render::{Renderable, TypeHelperRenderer};
-use genco::prelude::*;
+use uniffi_bindgen::interface::Type as UniFfiType;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CustomCodeType {
     name: String,
+    module_path: String,
+    builtin_type: Box<UniFfiType>,
 }
 
 impl CustomCodeType {
-    pub fn new(name: String) -> Self {
-        CustomCodeType { name }
+    pub fn new(name: String, module_path: String, builtin_type: Box<UniFfiType>) -> Self {
+        CustomCodeType { name, module_path, builtin_type }
+    }
+
+    pub fn as_type(&self) -> UniFfiType {
+        UniFfiType::Custom {
+            name: self.name.clone(),
+            module_path: self.module_path.clone(),
+            builtin: self.builtin_type.clone(),
+        }
     }
 }
+
+use super::oracle::{AsCodeType, DartCodeOracle};
+use super::CodeType;
 
 impl CodeType for CustomCodeType {
     fn type_label(&self) -> String {
         DartCodeOracle::class_name(&self.name)
     }
-
-    fn canonical_name(&self) -> String {
-        format!("Type{}", self.name)
-    }
 }
+
+use super::render::{Renderable, TypeHelperRenderer};
+use genco::prelude::*;
 
 impl Renderable for CustomCodeType {
     fn render_type_helper(&self, type_helper: &dyn TypeHelperRenderer) -> dart::Tokens {
-        if type_helper.check(&self.name) {
-            return quote!(); // Return empty to avoid code duplication
+        if type_helper.include_once_check(&self.canonical_name(), &self.as_type()) {
+            return quote!(); 
         }
 
-        let cls_name = &DartCodeOracle::class_name(&self.name);
-        let ffi_conv_name = &DartCodeOracle::class_name(&format!("FfiConverter{}", self.name));
+        let custom_dart_class_name = &self.type_label();
+        let ffi_converter_class_name = &self.ffi_converter_name();
 
-        // For custom types, we generate a simple wrapper class and FFI converter
-        // This assumes the custom type is a simple newtype wrapper
-        quote! {
-            class $cls_name {
-                final String value;
-                
-                const $cls_name(this.value);
-                
+        let builtin_codetype = (*self.builtin_type).as_codetype(); 
+        let builtin_dart_type_label_tokens = DartCodeOracle::dart_type_label(Some(&*self.builtin_type));
+        let builtin_ffi_native_type_tokens = DartCodeOracle::native_type_label(Some(&*self.builtin_type));
+
+        let custom_class = quote! {
+            class $custom_dart_class_name {
+                final $builtin_dart_type_label_tokens value;
+
+                const $custom_dart_class_name(this.value);
+
                 @override
-                String toString() => value;
-                
+                String toString() => value.toString();
+
                 @override
-                bool operator ==(Object other) {
-                    return other is $cls_name && other.value == value;
-                }
-                
+                bool operator ==(Object other) =>
+                    other is $custom_dart_class_name &&
+                    other.value == value;
+
                 @override
                 int get hashCode => value.hashCode;
             }
-            
-            class $ffi_conv_name {
-                static $cls_name lift(RustBuffer buf) {
-                    return $ffi_conv_name.read(buf.asUint8List()).value;
+        };
+
+        let converter_class = quote! {
+            class $ffi_converter_class_name {
+                static $custom_dart_class_name lift($(builtin_ffi_native_type_tokens.clone()) buf) {
+                    final builtinValue = $(&builtin_codetype.lift())(buf);
+                    return $custom_dart_class_name(builtinValue);
                 }
-                
-                static LiftRetVal<$cls_name> read(Uint8List buf) {
-                    // Custom types are typically strings (like Txid, Uuid, etc.)
-                    final stringResult = FfiConverterString.read(buf);
-                    return LiftRetVal($cls_name(stringResult.value), stringResult.bytesRead);
+
+                static $(builtin_ffi_native_type_tokens.clone()) lower($custom_dart_class_name value) {
+                    return $(&builtin_codetype.lower())(value.value);
                 }
-                
-                static RustBuffer lower($cls_name value) {
-                    return FfiConverterString.lower(value.value);
+
+                static LiftRetVal<$custom_dart_class_name> read($(builtin_ffi_native_type_tokens.clone()) buf, int offset) {
+                    final builtinResult = $(&builtin_codetype.read())(buf, offset);
+                    return LiftRetVal($custom_dart_class_name(builtinResult.value), builtinResult.bytesRead);
                 }
-                
-                static int write($cls_name value, Uint8List buf) {
-                    return FfiConverterString.write(value.value, buf);
+
+                static int write($custom_dart_class_name value, $builtin_ffi_native_type_tokens buf) {
+                    return $(&builtin_codetype.write())(value.value, buf);
                 }
-                
-                static int allocationSize($cls_name value) {
-                    return FfiConverterString.allocationSize(value.value);
+
+                static int allocationSize($custom_dart_class_name value) {
+                    return $(&builtin_codetype.ffi_converter_name()).allocationSize(value.value);
                 }
             }
+        };
+
+        quote! {
+            $custom_class
+            
+            $converter_class
         }
     }
 }

--- a/src/gen/custom.rs
+++ b/src/gen/custom.rs
@@ -1,0 +1,81 @@
+use super::oracle::DartCodeOracle;
+use super::CodeType;
+use super::render::{Renderable, TypeHelperRenderer};
+use genco::prelude::*;
+
+#[derive(Debug)]
+pub struct CustomCodeType {
+    name: String,
+}
+
+impl CustomCodeType {
+    pub fn new(name: String) -> Self {
+        CustomCodeType { name }
+    }
+}
+
+impl CodeType for CustomCodeType {
+    fn type_label(&self) -> String {
+        DartCodeOracle::class_name(&self.name)
+    }
+
+    fn canonical_name(&self) -> String {
+        format!("Type{}", self.name)
+    }
+}
+
+impl Renderable for CustomCodeType {
+    fn render_type_helper(&self, type_helper: &dyn TypeHelperRenderer) -> dart::Tokens {
+        if type_helper.check(&self.name) {
+            return quote!(); // Return empty to avoid code duplication
+        }
+
+        let cls_name = &DartCodeOracle::class_name(&self.name);
+        let ffi_conv_name = &DartCodeOracle::class_name(&format!("FfiConverter{}", self.name));
+
+        // For custom types, we generate a simple wrapper class and FFI converter
+        // This assumes the custom type is a simple newtype wrapper
+        quote! {
+            class $cls_name {
+                final String value;
+                
+                const $cls_name(this.value);
+                
+                @override
+                String toString() => value;
+                
+                @override
+                bool operator ==(Object other) {
+                    return other is $cls_name && other.value == value;
+                }
+                
+                @override
+                int get hashCode => value.hashCode;
+            }
+            
+            class $ffi_conv_name {
+                static $cls_name lift(RustBuffer buf) {
+                    return $ffi_conv_name.read(buf.asUint8List()).value;
+                }
+                
+                static LiftRetVal<$cls_name> read(Uint8List buf) {
+                    // Custom types are typically strings (like Txid, Uuid, etc.)
+                    final stringResult = FfiConverterString.read(buf);
+                    return LiftRetVal($cls_name(stringResult.value), stringResult.bytesRead);
+                }
+                
+                static RustBuffer lower($cls_name value) {
+                    return FfiConverterString.lower(value.value);
+                }
+                
+                static int write($cls_name value, Uint8List buf) {
+                    return FfiConverterString.write(value.value, buf);
+                }
+                
+                static int allocationSize($cls_name value) {
+                    return FfiConverterString.allocationSize(value.value);
+                }
+            }
+        }
+    }
+}

--- a/src/gen/mod.rs
+++ b/src/gen/mod.rs
@@ -19,6 +19,7 @@ use uniffi_bindgen::{BindingGenerator, ComponentInterface};
 mod callback_interface;
 mod code_type;
 mod compounds;
+mod custom;
 mod enums;
 mod functions;
 mod objects;

--- a/src/gen/oracle.rs
+++ b/src/gen/oracle.rs
@@ -611,7 +611,7 @@ impl<T: AsType> AsCodeType for T {
             Type::Enum { name, .. } => Box::new(enums::EnumCodeType::new(name)),
             Type::Record {name, .. } => Box::new(records::RecordCodeType::new(name)),
             Type::CallbackInterface { name, .. } => Box::new(callback_interface::CallbackInterfaceCodeType::new(name, self.as_type())),
-            Type::Custom { name, .. } => Box::new(custom::CustomCodeType::new(name)),
+            Type::Custom { name, module_path, builtin, .. } => Box::new(custom::CustomCodeType::new(name.clone(), module_path.clone(), builtin.clone())),
             _ => todo!("As Type for Type::{:?}", self.as_type()),
         }
     }

--- a/src/gen/oracle.rs
+++ b/src/gen/oracle.rs
@@ -10,7 +10,7 @@ use uniffi_bindgen::ComponentInterface;
 use crate::gen::primitives;
 
 // use super::render::{AsRenderable, Renderable};
-use super::{callback_interface, compounds, enums, objects, records};
+use super::{callback_interface, compounds, custom, enums, objects, records};
 
 pub struct DartCodeOracle;
 
@@ -610,6 +610,7 @@ impl<T: AsType> AsCodeType for T {
             Type::Enum { name, .. } => Box::new(enums::EnumCodeType::new(name)),
             Type::Record {name, .. } => Box::new(records::RecordCodeType::new(name)),
             Type::CallbackInterface { name, .. } => Box::new(callback_interface::CallbackInterfaceCodeType::new(name, self.as_type())),
+            Type::Custom { name, .. } => Box::new(custom::CustomCodeType::new(name)),
             _ => todo!("As Type for Type::{:?}", self.as_type()),
         }
     }

--- a/src/gen/oracle.rs
+++ b/src/gen/oracle.rs
@@ -598,6 +598,7 @@ impl<T: AsType> AsCodeType for T {
             Type::Boolean => Box::new(primitives::BooleanCodeType),
             Type::String => Box::new(primitives::StringCodeType),
             Type::Duration => Box::new(primitives::DurationCodeType),
+            Type::Bytes => Box::new(primitives::BytesCodeType),
             Type::Object { name, .. } => Box::new(objects::ObjectCodeType::new(name)),
             Type::Optional { inner_type } => Box::new(compounds::OptionalCodeType::new(
                 self.as_type(),

--- a/src/gen/render/mod.rs
+++ b/src/gen/render/mod.rs
@@ -32,6 +32,7 @@ pub trait Renderable {
             Type::Float32 | Type::Float64 => quote!(double),
             Type::String => quote!(String),
             Type::Boolean => quote!(bool),
+            Type::Bytes => quote!(Uint8List),
             Type::Object { name, .. } => quote!($name),
             Type::Optional { inner_type } => quote!($(&self.render_type(inner_type, type_helper))?),
             Type::Sequence { inner_type } => {
@@ -81,6 +82,7 @@ impl<T: AsType> AsRenderable for T {
             Type::Boolean => Box::new(primitives::BooleanCodeType),
             Type::String => Box::new(primitives::StringCodeType),
             Type::Duration => Box::new(primitives::DurationCodeType),
+            Type::Bytes => Box::new(primitives::BytesCodeType),
             Type::Object { name, .. } => Box::new(objects::ObjectCodeType::new(name)),
             Type::Optional { inner_type } => Box::new(compounds::OptionalCodeType::new(
                 self.as_type(),

--- a/src/gen/render/mod.rs
+++ b/src/gen/render/mod.rs
@@ -1,4 +1,4 @@
-use super::{callback_interface, compounds, enums, primitives, records};
+use super::{callback_interface, compounds, custom, enums, primitives, records};
 use super::{objects, oracle::AsCodeType};
 use genco::{lang::dart, quote};
 use uniffi_bindgen::interface::{AsType, Enum, Object, Record, Type};
@@ -45,6 +45,7 @@ pub trait Renderable {
             }
             Type::Enum { name, .. } => quote!($name),
             Type::Record { name, .. } => quote!($name),
+            Type::Custom { name, .. } => quote!($name),
             Type::Duration => quote!(Duration),
             Type::CallbackInterface { name, .. } => quote!($name),
             _ => todo!("Type::{:?}", ty),
@@ -91,6 +92,7 @@ impl<T: AsType> AsRenderable for T {
             )),
             Type::Enum { name, .. } => Box::new(enums::EnumCodeType::new(name)),
             Type::Record {name, .. } => Box::new(records::RecordCodeType::new(name)),
+            Type::Custom {name, .. } => Box::new(custom::CustomCodeType::new(name)),
             Type::CallbackInterface { name, .. } => Box::new(callback_interface::CallbackInterfaceCodeType::new(name, self.as_type())),
             _ => todo!("Renderable for Type::{:?}", self.as_type()),
         }

--- a/src/gen/render/mod.rs
+++ b/src/gen/render/mod.rs
@@ -94,7 +94,7 @@ impl<T: AsType> AsRenderable for T {
             )),
             Type::Enum { name, .. } => Box::new(enums::EnumCodeType::new(name)),
             Type::Record {name, .. } => Box::new(records::RecordCodeType::new(name)),
-            Type::Custom {name, .. } => Box::new(custom::CustomCodeType::new(name)),
+            Type::Custom {name, module_path, builtin, .. } => Box::new(custom::CustomCodeType::new(name.clone(), module_path.clone(), builtin.clone())),
             Type::CallbackInterface { name, .. } => Box::new(callback_interface::CallbackInterfaceCodeType::new(name, self.as_type())),
             _ => todo!("Renderable for Type::{:?}", self.as_type()),
         }

--- a/src/gen/types.rs
+++ b/src/gen/types.rs
@@ -439,6 +439,7 @@ pub fn generate_type(ty: &Type) -> dart::Tokens {
         Type::Enum { name, .. } => quote!($name),
         Type::Duration => quote!(Duration),
         Type::Record { name, .. } => quote!($name),
+        Type::Custom { name, .. } => quote!($name),
         _ => todo!("Type::{:?}", ty),
     }
 }

--- a/src/gen/types.rs
+++ b/src/gen/types.rs
@@ -432,6 +432,7 @@ pub fn generate_type(ty: &Type) -> dart::Tokens {
         | Type::UInt64 => quote!(int),
         Type::Float32 | Type::Float64 => quote!(double),
         Type::String => quote!(String),
+        Type::Bytes => quote!(Uint8List),
         Type::Object { name, .. } => quote!($name),
         Type::Boolean => quote!(bool),
         Type::Optional { inner_type } => quote!($(generate_type(inner_type))?),


### PR DESCRIPTION
Refactor custom.rs to support UniFFI 0.29 custom types

Implement generic handling of Type::Custom by delegating to builtin types.
This fixes the custom type support in uniffi-dart for UniFFI 0.29 by:

- Adding module_path support for local/external type distinction
- Making CustomCodeType generic over any builtin type (not just String)
- Generating Dart wrapper classes that delegate FFI conversion to the 
  underlying builtin type
- Fixing variable naming to match established patterns
- Removing unused code and improving readability

The implementation correctly handles custom types via the custom_type!
macro pattern introduced in UniFFI 0.29, replacing the deprecated
UniffiCustomTypeConverter trait.

Tested with a custom UUID type wrapping String to verify round-trip
conversions work correctly. Here: https://github.com/Johnosezele/uniffi-dart-test-project

Part of the upgrade to UniFFI 0.29.